### PR TITLE
Make settling permissionless & cleanup

### DIFF
--- a/packages/contracts/contracts/AuctionRaffle.sol
+++ b/packages/contracts/contracts/AuctionRaffle.sol
@@ -175,7 +175,7 @@ contract AuctionRaffle is Ownable, Config, BidModel, StateModel, VRFRequester {
      * @notice Allows a bidder to claim their funds after the raffle is settled.
      * Golden Ticket winner can withdraw the full bid amount.
      * Raffle winner can withdraw the bid amount minus `_reservePrice`.
-     * Non-winning bidder can withdraw the bid amount minus 2% fee.
+     * Non-winning bidder can withdraw the full bid amount.
      * Auction winner pays the full bid amount and is not entitled to any withdrawal.
      */
     function claim(uint256 bidderID) external onlyInState(State.RAFFLE_SETTLED) {

--- a/packages/contracts/contracts/AuctionRaffle.sol
+++ b/packages/contracts/contracts/AuctionRaffle.sol
@@ -126,7 +126,7 @@ contract AuctionRaffle is Ownable, Config, BidModel, StateModel, VRFRequester {
      * This is done to efficiently remove auction winners from _raffleParticipants array as they no longer take part
      * in the raffle.
      */
-    function settleAuction() external onlyOwner onlyInState(State.BIDDING_CLOSED) {
+    function settleAuction() external onlyInState(State.BIDDING_CLOSED) {
         _settleState = SettleState.AUCTION_SETTLED;
         uint256 biddersCount = getBiddersCount();
         uint256 raffleWinnersCount = _raffleWinnersCount;
@@ -154,7 +154,7 @@ contract AuctionRaffle is Ownable, Config, BidModel, StateModel, VRFRequester {
     /**
      * @notice Initiate raffle draw by requesting a random number from Chainlink VRF.
      */
-    function settleRaffle() external onlyOwner onlyInState(State.AUCTION_SETTLED) returns (uint256) {
+    function settleRaffle() external onlyInState(State.AUCTION_SETTLED) returns (uint256) {
         uint256 reqId = _getRandomNumber();
         emit RandomNumberRequested(reqId);
         return reqId;

--- a/packages/contracts/contracts/AuctionRaffle.sol
+++ b/packages/contracts/contracts/AuctionRaffle.sol
@@ -35,7 +35,6 @@ contract AuctionRaffle is Ownable, Config, BidModel, StateModel, VRFRequester {
     uint256[] _raffleParticipants;
 
     uint256[] _auctionWinners;
-    uint256[] _raffleWinners;
 
     bool _proceedsClaimed;
 

--- a/packages/contracts/test/contracts/AuctionRaffle.test.ts
+++ b/packages/contracts/test/contracts/AuctionRaffle.test.ts
@@ -380,8 +380,9 @@ describe('AuctionRaffle', function () {
       await bid(9)
     })
 
-    it('reverts if called not by owner', async function () {
-      await expect(auctionRaffle.settleAuction()).to.be.revertedWith('Ownable: caller is not the owner')
+    it('can be called by anyone', async function () {
+      await endBidding(auctionRaffleAsOwner)
+      await expect(auctionRaffle.settleAuction()).to.not.be.reverted
     })
 
     it('reverts if bidding is in progress', async function () {
@@ -483,8 +484,10 @@ describe('AuctionRaffle', function () {
       await bid(9)
     })
 
-    it('reverts if called not by owner', async function () {
-      await expect(auctionRaffle.settleRaffle()).to.be.revertedWith('Ownable: caller is not the owner')
+    it('can be called by anyone', async function () {
+      await endBidding(auctionRaffleAsOwner)
+      await auctionRaffle.settleAuction()
+      await expect(auctionRaffle.settleRaffle()).to.not.be.reverted
     })
 
     it('reverts if raffle is not settled', async function () {


### PR DESCRIPTION
- Remove `onlyOwner` modifier for `settleAuction` and `settleRaffle`
- Remove unused variable
- Update outdated natspec documentation